### PR TITLE
fix(turbo): add outputs for build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,13 @@
 {
     "$schema": "https://turbo.build/schema.json",
     "pipeline": {
-      "build": {},
-      "start": {},
+      "build": {
+        "outputs": ["public/**", "lib/**"],
+        "dependsOn": ["^build"]
+      },
       "check": {},
-      "dev": {}
+      "dev": {
+        "persistent": true
+      }
     }
   }


### PR DESCRIPTION
Hey! I made a few adjustments to your `turbo.json`:

```jsonc
"build": {
  // This instructs turbo to look for and cache `public` (for `sites/__dxp__`) and 
  //`lib` (for packages/__dxp__`) - outputs are relative to the workspace
  // docs: https://turbo.build/repo/docs/core-concepts/caching#configuring-cache-outputs
  "outputs": ["public/**", "lib/**"],
  // I noticed that `sites/__dxp__` lists `packages/__dxp__` as a dependency in 
  // your `package.json`. This will ensure that the `build` script of `packages/__dxp__` is 
  // always run before `sites/__dxp__` 
  // docs: https://turbo.build/repo/docs/reference/configuration#dependson
  "dependsOn": ["^build"]
},
"dev": {
  // mark this task as never ending
  // docs: https://turbo.build/repo/docs/reference/configuration#persistent
  "persistent": true
}
```

Without telling turbo where the outputs for a task are, it will only cache the logs (docs: https://turbo.build/repo/docs/core-concepts/caching#configuring-cache-outputs) from that run. Which means subsequent runs will be a cache hit, but no outputs will be restored - resulting in broken builds!